### PR TITLE
Fixed errors with GitHubParser.

### DIFF
--- a/src/codeplag/__main__.py
+++ b/src/codeplag/__main__.py
@@ -26,21 +26,23 @@ from codeplag.cplag.util import (
 pd.options.display.float_format = '{:,.2%}'.format
 
 logger = get_logger(__name__, LOG_PATH)
-try:
-    env_config = Config(RepositoryEnv('./.env'))
-except FileNotFoundError:
-    logger.debug('The environment file is not defined')
-else:
-    ACCESS_TOKEN = env_config.get('ACCESS_TOKEN', default='')
-    if not ACCESS_TOKEN:
-        logger.debug('GitHub access token is not defined')
 
 
 if __name__ == '__main__':
+    logger.debug("Starting codeplag util")
+    try:
+        env_config = Config(RepositoryEnv('./.env'))
+    except FileNotFoundError:
+        ACCESS_TOKEN = ''
+        logger.debug('The environment file is not defined')
+    else:
+        ACCESS_TOKEN = env_config.get('ACCESS_TOKEN', default='')
+        if not ACCESS_TOKEN:
+            logger.debug('GitHub access token is not defined')
+
     parser = get_parser()
     args = vars(parser.parse_args())
 
-    logger.debug("Starting codeplag util")
     logger.debug("Mode: {}; Extension: {}".format(args['mode'], args['extension']))
 
     MODE = args.pop('mode')

--- a/src/codeplag/brand_consts.py
+++ b/src/codeplag/brand_consts.py
@@ -1,7 +1,7 @@
 import argparse
 
 
-UTIL_VERSION = "0.0.6"
+UTIL_VERSION = "0.0.7"
 UTIL_NAME = "codeplag"
 
 

--- a/src/codeplag/consts.py
+++ b/src/codeplag/consts.py
@@ -4,12 +4,12 @@ import argparse
 LOG_PATH = "/tmp/codeplag.log"
 SUPPORTED_EXTENSIONS = {
     'py': [
-        r'.py\b'
+        r'.py$'
     ],
     'cpp': [
-        r'.cpp\b',
-        r'.c\b',
-        r'.h\b'
+        r'.cpp$',
+        r'.c$',
+        r'.h$'
     ]
 }
 COMPILE_ARGS = '-x c++ --std=c++11'.split()

--- a/src/webparsers/github_parser.py
+++ b/src/webparsers/github_parser.py
@@ -9,7 +9,7 @@ from webparsers.consts import LOG_PATH
 class GitHubParser:
     logger = get_logger(__name__, LOG_PATH)
 
-    def __init__(self, file_extensions=['py', 'c', 'cpp', 'h'],
+    def __init__(self, file_extensions=[r'.py$', r'.cpp$', r'.c$', r'.h$'],
                  check_policy=0, access_token=''):
         self.__access_token = access_token
         self.__check_all_branches = check_policy


### PR DESCRIPTION
Fixed error when .env file is not been created.
Now files which consist '.(extension)' in the filename ignored in the GitHubParser. Only if '.(extension)' consists in the end of file name.

Closes #92.