### PR TITLE
fix: correctly handle case when no same parts found.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-UTIL_VERSION            := 0.5.24
+UTIL_VERSION            := 0.5.25
 UTIL_NAME               := codeplag
 PWD                     := $(shell pwd)
 

--- a/src/templates/general.templ
+++ b/src/templates/general.templ
@@ -117,27 +117,29 @@
                     <th>{{ _("Similarity") }}, %</th>
                 </tr>
                 {% for first_head in same_parts_of_second %}
-                {% set second_head = same_parts_of_second[first_head][0].name %}
-                <tr class="table__row">
-                    <td rowspan="{{ len(same_parts_of_second[first_head]) }}">{{ first_head }}</td>
-                    <td>{{ second_head }}</td>
-                    {% set head_percent = same_parts_of_second[first_head].pop(0).percent %}
-                    {% if head_percent > threshold %}
-                        <td style="background-color: rgb(255, 200, 200); font-weight: bold;">{{ head_percent }}</td>
-                    {% else %}
-                        <td>{{ head_percent }}</td>
+                    {% if same_parts_of_second[first_head] %}
+                        {% set second_head = same_parts_of_second[first_head][0].name %}
+                        <tr class="table__row">
+                            <td rowspan="{{ len(same_parts_of_second[first_head]) }}">{{ first_head }}</td>
+                            <td>{{ second_head }}</td>
+                            {% set head_percent = same_parts_of_second[first_head].pop(0).percent %}
+                            {% if head_percent > threshold %}
+                                <td style="background-color: rgb(255, 200, 200); font-weight: bold;">{{ head_percent }}</td>
+                            {% else %}
+                                <td>{{ head_percent }}</td>
+                            {% endif %}
+                        </tr>
+                        {% for same_head_info in same_parts_of_second[first_head] %}
+                        <tr class="table__row">
+                            <td>{{ same_head_info.name }}</td>
+                            {% if same_head_info.percent > threshold %}
+                                <td style="background-color: rgb(255, 200, 200); font-weight: bold;">{{ same_head_info.percent }}</td>
+                            {% else %}
+                                <td>{{ same_head_info.percent }}</td>
+                            {% endif %}
+                        </tr>
+                        {% endfor %}
                     {% endif %}
-                </tr>
-                {% for same_head_info in same_parts_of_second[first_head] %}
-                <tr class="table__row">
-                    <td>{{ same_head_info.name }}</td>
-                    {% if same_head_info.percent > threshold %}
-                        <td style="background-color: rgb(255, 200, 200); font-weight: bold;">{{ same_head_info.percent }}</td>
-                    {% else %}
-                        <td>{{ same_head_info.percent }}</td>
-                    {% endif %}
-                </tr>
-                {% endfor %}
                 {% endfor %}
             </table>
             <table align="center" style="display: inline-table;">
@@ -148,27 +150,29 @@
                     <th>{{ _("Similarity") }}, %</th>
                 </tr>
                 {% for first_head in same_parts_of_first %}
-                {% set second_head = same_parts_of_first[first_head][0].name %}
-                <tr class="table__row">
-                    <td rowspan="{{ len(same_parts_of_first[first_head]) }}">{{ first_head }}</td>
-                    <td>{{ second_head }}</td>
-                    {% set head_percent = same_parts_of_first[first_head].pop(0).percent %}
-                    {% if head_percent > threshold %}
-                        <td style="background-color: rgb(255, 200, 200); font-weight: bold;">{{ head_percent }}</td>
-                    {% else %}
-                        <td>{{ head_percent }}</td>
+                    {% if same_parts_of_first[first_head] %}
+                        {% set second_head = same_parts_of_first[first_head][0].name %}
+                        <tr class="table__row">
+                            <td rowspan="{{ len(same_parts_of_first[first_head]) }}">{{ first_head }}</td>
+                            <td>{{ second_head }}</td>
+                            {% set head_percent = same_parts_of_first[first_head].pop(0).percent %}
+                            {% if head_percent > threshold %}
+                                <td style="background-color: rgb(255, 200, 200); font-weight: bold;">{{ head_percent }}</td>
+                            {% else %}
+                                <td>{{ head_percent }}</td>
+                            {% endif %}
+                        </tr>
+                        {% for same_head_info in same_parts_of_first[first_head] %}
+                        <tr class="table__row">
+                            <td>{{ same_head_info.name }}</td>
+                            {% if same_head_info.percent > threshold %}
+                                <td style="background-color: rgb(255, 200, 200); font-weight: bold;">{{ same_head_info.percent }}</td>
+                            {% else %}
+                                <td>{{ same_head_info.percent }}</td>
+                            {% endif %}
+                        </tr>
+                        {% endfor %}
                     {% endif %}
-                </tr>
-                {% for same_head_info in same_parts_of_first[first_head] %}
-                <tr class="table__row">
-                    <td>{{ same_head_info.name }}</td>
-                    {% if same_head_info.percent > threshold %}
-                        <td style="background-color: rgb(255, 200, 200); font-weight: bold;">{{ same_head_info.percent }}</td>
-                    {% else %}
-                        <td>{{ same_head_info.percent }}</td>
-                    {% endif %}
-                </tr>
-                {% endfor %}
                 {% endfor %}
             </table>
             </div>


### PR DESCRIPTION
When trying to create general report occurred error:
```
Oct 5 15:25:23 - [INFO] - codeplag - (codeplag).<module>(8) - Starting codeplag util (0.5.24) ...
Oct 5 15:25:25 - [ERROR] - codeplag - (codeplag).<module>(8) - An unexpected error occurred while running the utility - list object has no element 0. For getting more information, check file '/var/log/codeplag/codeplag.log'.
Oct 5 15:25:25 - [ERROR] - codeplag - (codeplag).<module>(8) - Trace:
Traceback (most recent call last):
  File "src/codeplag/__init__.py", line 29, in codeplag.main
  File "src/codeplag/utils.py", line 69, in codeplag.utils.CodeplagEngine.run
  File "src/codeplag/handlers/report.py", line 99, in codeplag.handlers.report.html_report_create
  File "src/codeplag/handlers/report.py", line 463, in codeplag.handlers.report.__html_report_create
  File "src/codeplag/handlers/report.py", line 371, in codeplag.handlers.report._create_general_report
  File "/usr/local/lib/python3.10/dist-packages/jinja2/environment.py", line 1295, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.10/dist-packages/jinja2/environment.py", line 942, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 120, in top-level template code
  File "/usr/local/lib/python3.10/dist-packages/jinja2/environment.py", line 490, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: list object has no element 0
```